### PR TITLE
Only run showhide and videos js when needed

### DIFF
--- a/assets/js/show-hide.js
+++ b/assets/js/show-hide.js
@@ -16,7 +16,11 @@ function showHide(shID) {
 }
 
 var st = document.getElementById('live-test-show');
-st.addEventListener("click", function(){showHide("live-test")});
+if (st) {
+  st.addEventListener("click", function(){showHide("live-test")});
+}
 
 var ht = document.getElementById('live-test-hide');
-ht.addEventListener("click", function(){showHide("live-test")});
+if (ht) {
+  ht.addEventListener("click", function(){showHide("live-test")});
+}

--- a/assets/js/videos.js
+++ b/assets/js/videos.js
@@ -1,7 +1,5 @@
 "use strict";
 
-console.log('Starting video JS');
-
 var ebwVideoInit = function() {
     return navigator.userAgent.indexOf('Opera Mini') === -1 &&
         'querySelector' in document &&
@@ -68,4 +66,8 @@ var videoShow = function() {
     });
 }
 
-videoShow();
+var videosExist = document.querySelector('.video');
+if (videosExist) {
+    console.log('Starting videos.js');
+    videoShow();
+}


### PR DESCRIPTION
This adds checks before running unnecessary video or show-hide JS on a page.