### PR TITLE
Update heading-titles.js to latest EBT, no window.onload

### DIFF
--- a/assets/js/heading-titles.js
+++ b/assets/js/heading-titles.js
@@ -1,16 +1,20 @@
+/*jslint browser */
+/*globals window, console */
+
+console.log('Running heading-titles.js...');
+
 // Give all headings title attributes (unless they already have one)
-function heading_titles() {
-    var x = document.querySelectorAll('h1,h2,h3,h4,h5,h6')
+function ebHeadingTitles() {
+    'use strict';
+    var headings = document.querySelectorAll('h1,h2,h3,h4,h5,h6');
     var i;
-    for (i = 0; i < x.length; i++) {
-      if (x[i].hasAttribute("title")) {;
-      } else {
-        x[i].setAttribute("title", x[i].textContent);
-      }
+    for (i = 0; i < headings.length; i += 1) {
+        if (!headings[i].hasAttribute('title')) {
+            headings[i].setAttribute('title', headings[i].textContent);
+            console.log('Set title attribute on heading "' + headings[i].textContent + '"');
+        } else {
+            console.log('Heading "' + headings[i].textContent + '" already has title attribute.');
+        }
     }
 }
-// Run this on window.onload for Prince
-// see http://www.princexml.com/doc/javascript/
-window.onload = function() {
-    heading_titles();
-}
+ebHeadingTitles();

--- a/assets/js/shift-elements.js
+++ b/assets/js/shift-elements.js
@@ -1,5 +1,5 @@
-/*jslint browser*/
-/*globals window */
+/*jslint browser, for */
+/*globals window, console */
 
 // Shits an element up or down the DOM.
 // Design to run in PDF outputs only.


### PR DESCRIPTION
@LaurenEllwood This fixes the issue where loading `heading-titles.js` before `shift-elements.js` broke running heads. I've updated `heading-titles.js` to the latest EBT version, which doesn't use an old practice of waiting for the `window.onload` event in Prince. I'm not sure why this was an issue.