### PR TITLE
COVID-19 book links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -138,6 +138,7 @@ exclude:
 # - childhood-hiv
 # - childhood-tb
 # - congenital-disorders
+# - covid-19-guide-for-community-health-workers
 # - ebola-prevention-and-control
 # - facilitators-guide
 # - fetal-heart-rate-handbook
@@ -171,6 +172,7 @@ keep_files:
 # - childhood-hiv
 # - childhood-tb
 # - congenital-disorders
+# - covid-19-guide-for-community-health-workers
 # - ebola-prevention-and-control
 # - facilitators-guide
 # - fetal-heart-rate-handbook

--- a/_data/products.yml
+++ b/_data/products.yml
@@ -14,6 +14,8 @@
   url: "https://bettercare.co.za/childhood-tb"
 - slug: "congenital-disorders"
   url: "https://bettercare.co.za/congenital-disorders"
+- slug: "covid-19-guide-for-community-health-workers"
+  url: "https://bettercare.co.za/covid-19-guide-for-community-health-workers/"
 - slug: "ebola-prevention-and-control"
   url: "https://bettercare.co.za/ebola-prevention-and-control"
 - slug: "facilitators-guide"

--- a/_includes/cover
+++ b/_includes/cover
@@ -19,14 +19,24 @@ Adjust HTML based on output format.
 {% assign image-filetype = image | split: "." %}
 {% assign image-without-filetype = image | replace: image-filetype[1], "" | replace: ".", "" %}
 
-<p class="cover"><a href="{{ web-start-page }}"><img src="{{ images }}/{{ image }}"{% if site.output == "web" %} srcset="{{ images }}/{{ image-without-filetype }}-320.{{ image-filetype[1] }} 320w, {{ images }}/{{ image-without-filetype }}-640.{{ image-filetype[1] }} 640w, {{ images }}/{{ image-without-filetype }}-1024.{{ image-filetype[1] }} 1024w, {{ images }}/{{ image-without-filetype }}.{{ image-filetype[1] }} 1280w" sizes="(min-width: 40em) 40em, 100vw" {% endif %}alt="{{ title }}" class="cover"></a></p>
+<p class="cover"><a href="{{ web-start-page }}{% unless web-start-page contains ".html" %}.html{% endunless %}"><img src="{{ images }}/{{ image }}"{% if site.output == "web" %} srcset="{{ images }}/{{ image-without-filetype }}-320.{{ image-filetype[1] }} 320w, {{ images }}/{{ image-without-filetype }}-640.{{ image-filetype[1] }} 640w, {{ images }}/{{ image-without-filetype }}-1024.{{ image-filetype[1] }} 1024w, {{ images }}/{{ image-without-filetype }}.{{ image-filetype[1] }} 1280w" sizes="(min-width: 40em) 40em, 100vw" {% endif %}alt="{{ title }}" class="cover"></a></p>
 
 {% elsif site.output == "screen-pdf" %}
 
 {% comment %}Add the cover to the PDF bookmarks without displaying it{% endcomment %}
 <h1 style="position: absolute; z-index: -1">Cover</h1>
 
-<p class="cover"><img src="{{ images }}/{{ image }}" srcset="{{ images }}/{{ image-without-filetype }}-320.{{ image-filetype[1] }} 320w, {{ images }}/{{ image-without-filetype }}-640.{{ image-filetype[1] }} 640w, {{ images }}/{{ image-without-filetype }}-1024.{{ image-filetype[1] }} 1024w, {{ images }}/{{ image-without-filetype }}.{{ image-filetype[1] }} 1280w" sizes="(min-width: 40em) 40em, 100vw" alt="{{ title }}" class="cover"></p>
+<p class="cover">
+	<img src="{{ images }}/{{ image }}" class="cover">
+</p>
+
+{% elsif site.output == "app" %}
+
+<p class="cover">
+	<a href="{{ app-start-page }}{% unless app-start-page contains ".html" %}.html{% endunless %}">
+		<img src="{{ images }}/{{ image }}" alt="{{ title }}" class="cover">
+	</a>
+</p>
 
 {% else %}
 


### PR DESCRIPTION
This adds a buy-the-book button to the new COVID-19 book, and fixes a bug that broke links from covers to contents pages (e.g. at https://bettercare.co.za/learn/covid-19-guide-for-community-health-workers/text/).

Also adds new book to config for excludes/keeps.